### PR TITLE
Datepicker format is case sensitive.

### DIFF
--- a/ui/helpers/ui.php
+++ b/ui/helpers/ui.php
@@ -786,7 +786,7 @@ abstract class PrismUI
                 ->addScriptDeclaration(
                     'jQuery(document).ready(function($) {
                         jQuery("#' . $id . '_datepicker").datetimepicker({
-                            format: "' . strtoupper($calendarDateFormat) . '",
+                            format: "' . $calendarDateFormat . '",
                             locale: "' . strtolower($locale) . '",
                             allowInputToggle: true
                         });


### PR DESCRIPTION
Date picker format needs to be case sensitive. For example: "YYYY-MM-DD HH:mm" is not the same as "YYYY-MM-DD HH:MM".